### PR TITLE
Add payment activity to android Manifest to support intent to payment Activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="ipay.gh.com.ipayandroidsdk.PaymentActivity"></activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
Noticed that activity wont launch after integration to my project. Thus i realized that the activity was not declared in android manifest, therefore i had to declare it and it launched.  Hope you will accept my PR and merge so that others don't face same problem.