### PR TITLE
Check for payment mode selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="ipay.gh.com.ipayandroidsdk.PaymentActivity"></activity>
     </application>
 
 </manifest>

--- a/ipayandroidsdk/src/main/java/ipay/gh/com/ipayandroidsdk/PaymentActivity.java
+++ b/ipayandroidsdk/src/main/java/ipay/gh/com/ipayandroidsdk/PaymentActivity.java
@@ -84,13 +84,17 @@ public class PaymentActivity extends AppCompatActivity {
         niceSpinner = findViewById(R.id.nice_spinner);
         niceSpinner.setTypeface(font);
         voucherCode.setTypeface(font);
-        final List<String> dataset = new LinkedList<>(Arrays.asList("MTN Money", "Vodafone Cash", "Tigo Cash", "Airtel Money", "Visa / Mastercard"));
+        final List<String> dataset = new LinkedList<>(Arrays.asList("Select Payment Network","MTN Money", "Vodafone Cash", "Tigo Cash", "Airtel Money", "Visa / Mastercard"));
         niceSpinner.attachDataSource(dataset);
 
         niceSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener( ) {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 switch (dataset.get(position)) {
+                    case "Select Payment Network":
+                        voucherCode.setVisibility(View.INVISIBLE);
+                        networkName = "";
+                        break;
                     case "Vodafone Cash":
                         voucherCode.setVisibility(View.VISIBLE);
                         networkName = "vodafone";
@@ -116,7 +120,7 @@ public class PaymentActivity extends AppCompatActivity {
 
             @Override
             public void onNothingSelected(AdapterView<?> parent) {
-
+                networkName = "";
             }
         });
 
@@ -128,26 +132,35 @@ public class PaymentActivity extends AppCompatActivity {
                  */
                 //KeyUtilities ku = new KeyUtilities("close", PaymentActivity.this);
                 //ku.hideKeyboard();
+                if ( networkName != ""){
 
-                if (mobileNumber.getText( ).toString( ).isEmpty( )) {
+                    if (mobileNumber.getText( ).toString( ).isEmpty( )) {
                         TastyToast.makeText(getApplicationContext( ), "Mobile Number cannot be empty.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
-                } else {
-                    if (mobileNumber.getText().toString().startsWith("0") && mobileNumber.getText( ).length( ) < 10) {
-                        TastyToast.makeText(getApplicationContext(), "Mobile Number cannot be less than 10 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
-                    } else if (mobileNumber.getText().toString().startsWith("2") && mobileNumber.getText( ).length( ) > 12) {
-                        TastyToast.makeText(getApplicationContext(), "Mobile Number cannot be more than 12 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
-                    } else if (voucherCode.getVisibility( ) == View.VISIBLE) {
-                        if (voucherCode.getText().length() < 6) {
-                            TastyToast.makeText(getApplicationContext(), "Voucher code cannot be less than 6 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
-                        } else if (voucherCode.getText().length() >= 6 && mobileNumber.getText( ).length( ) < 10) {
+                    } else {
+                        if (mobileNumber.getText().toString().startsWith("0") && mobileNumber.getText( ).length( ) < 10 ) {
                             TastyToast.makeText(getApplicationContext(), "Mobile Number cannot be less than 10 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
+                        } else if (mobileNumber.getText().toString().startsWith("2") && mobileNumber.getText( ).length( ) > 12) {
+                            TastyToast.makeText(getApplicationContext(), "Mobile Number cannot be more than 12 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
+                        } else if (voucherCode.getVisibility( ) == View.VISIBLE) {
+                            if (voucherCode.getText().length() < 6) {
+                                TastyToast.makeText(getApplicationContext(), "Voucher code cannot be less than 6 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
+                            } else if (voucherCode.getText().length() >= 6 && mobileNumber.getText( ).length( ) < 10) {
+                                TastyToast.makeText(getApplicationContext(), "Mobile Number cannot be less than 10 characters long.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
+                            } else {
+                                makePayment(payment);
+                            }
                         } else {
                             makePayment(payment);
                         }
-                    } else {
-                        makePayment(payment);
                     }
+
                 }
+                else {
+                    //If no Network or Payment Mode Selected
+                    TastyToast.makeText(getApplicationContext( ), "Select a Payment Network.", TastyToast.LENGTH_LONG, TastyToast.ERROR).setGravity(Gravity.TOP, 0, 0);
+                }
+
+
             }
         });
 


### PR DESCRIPTION
Added a check for selected payment mode before processing payment. This is to avoid cases whereby an empty string is set for extra_wallet_issuer_hint in the API request, resulting in Merchant not allowed to process payments for this Issuer error. I faced this issue when i integrated the SDK in my App and thus after i fixed it taught i should make a commit. I will appreciate if my commit is merged or feedback provided. Thanks :)